### PR TITLE
Change ParseFile to an overload to Parse and make it public

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage as a library:
 
 ```csharp
 var parser = new EditorConfigParser();
-var configuration = parser.Parse(fileName).First();
+var configuration = parser.Parse(fileName);
 foreach (var kv in configuration.Properties)
 {
     Console.WriteLine("{0}={1}", kv.Key, kv.Value);

--- a/src/EditorConfig.Core/EditorConfigParser.cs
+++ b/src/EditorConfig.Core/EditorConfigParser.cs
@@ -51,19 +51,16 @@ namespace EditorConfig.Core
 		public IEnumerable<FileConfiguration> Parse(params string[] fileNames)
 		{
 			return fileNames
-				.Select(f => f
-					.Trim()
-					.Trim(new[] { '\r', '\n' })
-				)
-				.Select(this.ParseFile)
+				.Select(this.Parse)
 				.ToList();
 		}
 
-		private FileConfiguration ParseFile(string fileName)
+		public FileConfiguration Parse(string fileName)
 		{
-			Debug.WriteLine(":: {0} :: {1}", this.ConfigFileName, fileName);
+			var file = fileName.Trim().Trim(new[] {'\r', '\n'});
+			Debug.WriteLine(":: {0} :: {1}", this.ConfigFileName, file);
 
-			var fullPath = Path.GetFullPath(fileName).Replace(@"\", "/");
+			var fullPath = Path.GetFullPath(file).Replace(@"\", "/");
 			var configFiles = this.AllParentConfigFiles(fullPath);
 
 			//All the .editorconfig files going from root =>.fileName
@@ -85,7 +82,7 @@ namespace EditorConfig.Core
 			foreach (var kv in allProperties)
 				properties[kv.Key] = kv.Value;
 
-			return new FileConfiguration(ParseVersion, fileName, properties);
+			return new FileConfiguration(ParseVersion, file, properties);
 		}
 
 		private bool IsMatch(string glob, string fileName, string directory)

--- a/src/EditorConfig.Tests/EditorConfigTestBase.cs
+++ b/src/EditorConfig.Tests/EditorConfigTestBase.cs
@@ -24,8 +24,8 @@ namespace EditorConfig.Tests
 			var file = this.GetFileFromMethod(method, fileName);
 			var parser = new EditorConfigParser(configurationFile);
 			var fileConfigs = parser.Parse(file);
-			fileConfigs.Should().NotBeEmpty();
-			return fileConfigs.First();
+			fileConfigs.Should().NotBeNull();
+			return fileConfigs;
 		}
 
 		protected string GetFileFromMethod(MethodBase method, string fileName)


### PR DESCRIPTION
This makes working with only one file much easier than it was before (also, there is no reason to only have array version available).