### PR TITLE
Cache the processing of EditorConfigFile.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:

--- a/src/EditorConfig.App/ArgumentsParser.cs
+++ b/src/EditorConfig.App/ArgumentsParser.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace EditorConfig.App
 {

--- a/src/EditorConfig.App/EditorConfig.App.csproj
+++ b/src/EditorConfig.App/EditorConfig.App.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EditorConfig.App</AssemblyName>
-    <RootNamespace>ReleaseNotes</RootNamespace>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>editorconfig</ToolCommandName>
     <PackageId>editorconfig-tool</PackageId>

--- a/src/EditorConfig.Core/ConfigSection.cs
+++ b/src/EditorConfig.Core/ConfigSection.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace EditorConfig.Core
 {
@@ -11,17 +10,17 @@ namespace EditorConfig.Core
 	{
 		private readonly Dictionary<string, string> _backingDictionary;
 
-		private static readonly Dictionary<string, string> DefaultGlobalDictionary = new Dictionary<string, string>();
 		/// <summary> Represents an ini section within the editorconfig file </summary>
-		public ConfigSection() => _backingDictionary = DefaultGlobalDictionary;
-
-		/// <summary> Represents an ini section within the editorconfig file </summary>
-		public ConfigSection(string name, string configDirectory, Dictionary<string, string> backingDictionary)
+		public ConfigSection(string name, IEditorConfigFile origin, Dictionary<string, string> backingDictionary)
 		{
-			Glob = FixGlob(name, configDirectory);
+			EditorConfigFile = origin;
+			Glob = FixGlob(name, origin.Directory);
 			_backingDictionary = backingDictionary ?? new Dictionary<string, string>();
 			ParseKnownProperties();
 		}
+
+		/// <summary> Originating <see cref="EditorConfigFile"/> </summary>
+		public IEditorConfigFile EditorConfigFile { get; }
 
 		/// <summary> The glob pattern this section describes</summary>
 		public string Glob { get; }

--- a/src/EditorConfig.Core/EditorConfigFileCache.cs
+++ b/src/EditorConfig.Core/EditorConfigFileCache.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace EditorConfig.Core;
+
+/// <summary>
+/// Cache unchanged parsed EditorConfigFiles.
+/// </summary>
+public static class EditorConfigFileCache
+{
+	private static string GetFileHash(string filename)
+	{
+		using var sha256 = System.Security.Cryptography.SHA256.Create();
+		using var stream = File.OpenRead(filename);
+		var hash = sha256.ComputeHash(stream);
+		return BitConverter.ToString(hash).Replace("-", "");
+	}
+
+	private static readonly ConcurrentDictionary<string, EditorConfigFile> FileCache = new();
+
+	/// <summary>
+	/// Retrieves a cached EditorConfigFile based on the file name and file hash.
+	/// The cache will be populated when the file was not present.
+	/// </summary>
+	/// <remarks>This function is thread safe. The cache will not be hit when the file does not exist.</remarks>
+	/// <param name="file"></param>
+	/// <returns></returns>
+	public static EditorConfigFile GetOrCreate(string file)
+	{
+		if (File.Exists(file))
+		{
+			var key = $"{file}_{GetFileHash(file)}";
+			return FileCache.GetOrAdd(key, _ => new EditorConfigFile(file));
+		}
+		else
+		{
+			return new EditorConfigFile(file);
+		}
+	}
+}

--- a/src/EditorConfig.Core/EditorConfigFileCache.cs
+++ b/src/EditorConfig.Core/EditorConfigFileCache.cs
@@ -28,14 +28,9 @@ public static class EditorConfigFileCache
 	/// <returns></returns>
 	public static EditorConfigFile GetOrCreate(string file)
 	{
-		if (File.Exists(file))
-		{
-			var key = $"{file}_{GetFileHash(file)}";
-			return FileCache.GetOrAdd(key, _ => new EditorConfigFile(file));
-		}
-		else
-		{
-			return new EditorConfigFile(file);
-		}
+		if (!File.Exists(file)) return new EditorConfigFile(file);
+
+		var key = $"{file}_{GetFileHash(file)}";
+		return FileCache.GetOrAdd(key, _ => new EditorConfigFile(file));
 	}
 }

--- a/src/EditorConfig.Core/EditorConfigParser.cs
+++ b/src/EditorConfig.Core/EditorConfigParser.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace EditorConfig.Core
 {

--- a/src/EditorConfig.Core/EditorConfigParser.cs
+++ b/src/EditorConfig.Core/EditorConfigParser.cs
@@ -102,7 +102,7 @@ namespace EditorConfig.Core
 
 		private IEnumerable<EditorConfigFile> ParseConfigFilesTillRoot(IEnumerable<string> configFiles)
 		{
-			foreach (var configFile in configFiles.Select(f=> new EditorConfigFile(f)))
+			foreach (var configFile in configFiles.Select(EditorConfigFileCache.GetOrCreate))
 			{
 				yield return configFile;
 				if (configFile.IsRoot) yield break;

--- a/src/EditorConfig.Core/EditorConfigParser.cs
+++ b/src/EditorConfig.Core/EditorConfigParser.cs
@@ -12,6 +12,8 @@ namespace EditorConfig.Core
 	/// </summary>
 	public class EditorConfigParser
 	{
+		private Func<string, EditorConfigFile> Factory { get; }
+
 		/// <summary>
 		/// The current (and latest parser supported) version as string
 		/// </summary>
@@ -40,7 +42,23 @@ namespace EditorConfig.Core
 		/// <param name="configFileName">The name of the file(s) holding the editorconfiguration values</param>
 		/// <param name="developmentVersion">Only used in testing, development to pass an older version to the parsing routine</param>
 		public EditorConfigParser(string configFileName = ".editorconfig", Version developmentVersion = null)
+			: this(f => new EditorConfigFile(f), configFileName, developmentVersion)
 		{
+
+		}
+
+		/// <summary>
+		/// The EditorConfigParser locates all relevant editorconfig files and makes sure they are merged correctly.
+		/// </summary>
+		/// <param name="factory">
+		/// Function that take the file name and constructs a new EditorConfigFile instance.
+		/// Pass `EditorConfigFileCache.GetOrCreate` to apply caching.
+		/// </param>
+		/// <param name="configFileName"></param>
+		/// <param name="developmentVersion"></param>
+		public EditorConfigParser(Func<string, EditorConfigFile> factory, string configFileName = ".editorconfig", Version developmentVersion = null)
+		{
+			Factory = factory;
 			ConfigFileName = configFileName ?? ".editorconfig";
 			ParseVersion = developmentVersion ?? Version;
 		}
@@ -102,7 +120,7 @@ namespace EditorConfig.Core
 
 		private IEnumerable<EditorConfigFile> ParseConfigFilesTillRoot(IEnumerable<string> configFiles)
 		{
-			foreach (var configFile in configFiles.Select(EditorConfigFileCache.GetOrCreate))
+			foreach (var configFile in configFiles.Select(Factory))
 			{
 				yield return configFile;
 				if (configFile.IsRoot) yield break;

--- a/src/EditorConfig.Core/EditorConfigWorkspace.cs
+++ b/src/EditorConfig.Core/EditorConfigWorkspace.cs
@@ -25,8 +25,7 @@ namespace EditorConfig.Core
 			var directory = rootEditorConfigFile.Directory;
 			_editorconfigFiles =
 				directory.EnumerateFiles(configFileName, SearchOption.AllDirectories)
-					.Select(d=>new EditorConfigFile(d.Name));
-
+					.Select(d=> EditorConfigFileCache.GetOrCreate(d.Name));
 		}
 
 

--- a/src/EditorConfig.Core/FileConfiguration.cs
+++ b/src/EditorConfig.Core/FileConfiguration.cs
@@ -72,6 +72,11 @@ namespace EditorConfig.Core
 		public Version Version { get; }
 
 		/// <summary>
+		/// Editorconfig files that were used to construct this instance of <see cref="FileConfiguration"/>
+		/// </summary>
+		public IReadOnlyCollection<IEditorConfigFile> EditorConfigFiles { get; }
+
+		/// <summary>
 		/// Holds the editor configuration for a file, please use <see cref="EditorConfigParser.Parse(string[])"/> to get an instance
 		/// </summary>
 		internal FileConfiguration(Version version, string fileName, List<ConfigSection> sections)
@@ -79,6 +84,7 @@ namespace EditorConfig.Core
 			if (version == null) throw new ArgumentNullException(nameof(version));
 			if (string.IsNullOrWhiteSpace(fileName)) throw new ArgumentException("file should not be null or whitespace", nameof(fileName));
 
+			EditorConfigFiles = sections.Select(s => s.EditorConfigFile).ToArray();
 			FileName = fileName;
 			Version = version;
 			Sections = sections;

--- a/src/EditorConfig.Tests/Caching/.editorconfig
+++ b/src/EditorConfig.Tests/Caching/.editorconfig
@@ -1,0 +1,4 @@
+﻿root = true
+
+[*]
+end_of_line = lf

--- a/src/EditorConfig.Tests/Caching/CachingTests.cs
+++ b/src/EditorConfig.Tests/Caching/CachingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using EditorConfig.Core;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace EditorConfig.Tests.Caching
@@ -11,10 +12,14 @@ namespace EditorConfig.Tests.Caching
 		public void FileShouldCached()
 		{
 			var fileName = GetFileFromMethod(MethodBase.GetCurrentMethod(),  ".editorconfig");
+
 			var parser = new EditorConfigParser(EditorConfigFileCache.GetOrCreate);
 			var config1 = parser.Parse(fileName);
+			config1.EditorConfigFiles.Should().NotBeNullOrEmpty();
+			config1.EditorConfigFiles.Should().OnlyContain(f => !string.IsNullOrEmpty(f.CacheKey));
 			var config2 = parser.Parse(fileName);
-			// Not sure how to assert this...
+			config2.EditorConfigFiles.Should().NotBeNullOrEmpty();
+			config2.EditorConfigFiles.Should().OnlyContain(f => !string.IsNullOrEmpty(f.CacheKey));
 		}
 	}
 }

--- a/src/EditorConfig.Tests/Caching/CachingTests.cs
+++ b/src/EditorConfig.Tests/Caching/CachingTests.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+using EditorConfig.Core;
+using NUnit.Framework;
+
+namespace EditorConfig.Tests.Caching
+{
+	[TestFixture]
+	public class CachingTests : EditorConfigTestBase
+	{
+		[Test]
+		public void FileShouldCached()
+		{
+			var fileName = GetFileFromMethod(MethodBase.GetCurrentMethod(),  ".editorconfig");
+			var parser = new EditorConfigParser(EditorConfigFileCache.GetOrCreate);
+			var config1 = parser.Parse(fileName);
+			var config2 = parser.Parse(fileName);
+			// Not sure how to assert this...
+		}
+	}
+}


### PR DESCRIPTION
Hello, I would like to introduce some basic caching for the parsing of the editorconfig files.
In my use case, I would call `new EditorConfig.Core.EditorConfigParser().Parse(fileName = fsharpFile)` for a bunch of files (200+) and they all get their settings from the same editorconfig.
So, I would like to only process that file once.