### PR TITLE
Adding support for passing an IFileSystem when parsing an editorconfig

### DIFF
--- a/src/EditorConfig.Core/EditorConfig.Core.csproj
+++ b/src/EditorConfig.Core/EditorConfig.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>editorconfig</PackageId>
 		<Description>EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readibly and they work nicely with version control systems. This is the core library of EditorConfig written ported to .NET.</Description>
 		<PackageTags>development editor IDE coding-style editorconfig</PackageTags>
@@ -12,6 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.2" PrivateAssets="all" />
 		<PackageReference Update="MinVer" Version="4.1.0" />
+		<PackageReference Include="System.IO.Abstractions" Version="19.2.29" />
 	</ItemGroup>
-
 </Project>

--- a/src/EditorConfig.Core/EditorConfigFile.cs
+++ b/src/EditorConfig.Core/EditorConfigFile.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -62,20 +62,20 @@ namespace EditorConfig.Core
 		/// <inheritdoc cref="IEditorConfigFile.IsRoot"/>
 		public bool IsRoot => _isRoot;
 
-		internal EditorConfigFile(string path, string cacheKey = null)
+		internal EditorConfigFile(string path, IFileSystem fileSystem, string cacheKey = null)
 		{
-			Directory = Path.GetDirectoryName(path);
-			FileName = Path.GetFileName(path);
+			Directory = fileSystem.Path.GetDirectoryName(path);
+			FileName = fileSystem.Path.GetFileName(path);
 			CacheKey = cacheKey;
-			Parse(path);
+			Parse(path, fileSystem);
 
 			if (_globalDict.TryGetValue("root", out var value))
 				bool.TryParse(value, out _isRoot);
 		}
 
-		private void Parse(string file)
+		private void Parse(string file, IFileSystem fileSystem)
 		{
-			var lines = File.ReadLines(file);
+			var lines = fileSystem.File.ReadLines(file);
 
 			var activeDict = _globalDict;
 			var sectionName = string.Empty;

--- a/src/EditorConfig.Tests/Caching/CachingTests.cs
+++ b/src/EditorConfig.Tests/Caching/CachingTests.cs
@@ -2,6 +2,7 @@
 using EditorConfig.Core;
 using FluentAssertions;
 using NUnit.Framework;
+using System.IO.Abstractions;
 
 namespace EditorConfig.Tests.Caching
 {
@@ -13,7 +14,7 @@ namespace EditorConfig.Tests.Caching
 		{
 			var fileName = GetFileFromMethod(MethodBase.GetCurrentMethod(),  ".editorconfig");
 
-			var parser = new EditorConfigParser(EditorConfigFileCache.GetOrCreate);
+			var parser = new EditorConfigParser(f => EditorConfigFileCache.GetOrCreate(f, new FileSystem()));
 			var config1 = parser.Parse(fileName);
 			config1.EditorConfigFiles.Should().NotBeNullOrEmpty();
 			config1.EditorConfigFiles.Should().OnlyContain(f => !string.IsNullOrEmpty(f.CacheKey));


### PR DESCRIPTION
I'm looking at [adding editorconfig support to CSharpier](https://github.com/belav/csharpier/issues/630), but CSharpier currently uses `System.IO.Abstractions.IFileSystem` instead of `System.IO` directly, which will cause some pain with CSharpier's tests. Switching `editorconfig-core-net` to `IFileSystem` was pretty straightforward except that it doesn't support `net45` or `netstandard1.3`.

I can switch this PR to use conditional compilation and get things working with `net45` and `netstandard1.3` if you still want to support them. But figured I'd submit it this way first and avoid doing that extra work if they are no longer needed.