### PR TITLE
Allow EditorConfigFile to be used in-memory without access or use of physical file system.

### DIFF
--- a/src/EditorConfig.Core/ConfigSection.cs
+++ b/src/EditorConfig.Core/ConfigSection.cs
@@ -70,6 +70,8 @@ namespace EditorConfig.Core
 
 		private static string FixGlob(string glob, string directory)
 		{
+			if (string.IsNullOrEmpty(directory)) return glob;
+
 			switch (glob.IndexOf('/'))
 			{
 				case -1: glob = "**/" + glob; break;

--- a/src/EditorConfig.Core/EditorConfigFile.cs
+++ b/src/EditorConfig.Core/EditorConfigFile.cs
@@ -84,10 +84,10 @@ namespace EditorConfig.Core
 
 		/// <summary> Parses EditorConfig file from the text reader. </summary>
 		/// <param name="reader"> Text reader. </param>
-		/// <param name="directory"> EditorConfig directory files to be matched to. </param>
-		/// <param name="fileName"> EditorConfig file name. </param>
+		/// <param name="directory"> EditorConfig base directory to match file sections to. Default is null. </param>
+		/// <param name="fileName"> EditorConfig file name. Default is '.editorconfig'. </param>
 		/// <returns> Parsed EditorConfig file. </returns>
-		public static EditorConfigFile Parse(TextReader reader, string directory, string fileName = ".editorconfig") =>
+		public static EditorConfigFile Parse(TextReader reader, string directory = null, string fileName = ".editorconfig") =>
 			new(fileName, directory, reader);
 
 		internal static EditorConfigFile Parse(string path, string cacheKey)

--- a/src/EditorConfig.Core/EditorConfigFileCache.cs
+++ b/src/EditorConfig.Core/EditorConfigFileCache.cs
@@ -28,9 +28,9 @@ public static class EditorConfigFileCache
 	/// <returns></returns>
 	public static EditorConfigFile GetOrCreate(string file)
 	{
-		if (!File.Exists(file)) return new EditorConfigFile(file);
+		if (!File.Exists(file)) return EditorConfigFile.Parse(file);
 
 		var key = $"{file}_{GetFileHash(file)}";
-		return FileCache.GetOrAdd(key, _ => new EditorConfigFile(file, key));
+		return FileCache.GetOrAdd(key, _ => EditorConfigFile.Parse(file, key));
 	}
 }

--- a/src/EditorConfig.Core/EditorConfigParser.cs
+++ b/src/EditorConfig.Core/EditorConfigParser.cs
@@ -41,7 +41,7 @@ namespace EditorConfig.Core
 		/// <param name="configFileName">The name of the file(s) holding the editorconfiguration values</param>
 		/// <param name="developmentVersion">Only used in testing, development to pass an older version to the parsing routine</param>
 		public EditorConfigParser(string configFileName = ".editorconfig", Version developmentVersion = null)
-			: this(f => new EditorConfigFile(f), configFileName, developmentVersion)
+			: this(EditorConfigFile.Parse, configFileName, developmentVersion)
 		{
 
 		}

--- a/src/EditorConfig.Core/EditorConfigParser.cs
+++ b/src/EditorConfig.Core/EditorConfigParser.cs
@@ -91,13 +91,13 @@ namespace EditorConfig.Core
 			var sections =
 				from configFile in editorConfigFiles
 				from section in configFile.Sections
-				where IsMatch(section.Glob, fullPath, configFile.Directory)
+				where IsMatch(section.Glob, fullPath)
 				select section;
 
 			return new FileConfiguration(ParseVersion, file, sections.ToList());
 		}
 
-		private bool IsMatch(string glob, string fileName, string directory)
+		private bool IsMatch(string glob, string fileName)
 		{
 			var matcher = GlobMatcher.Create(glob, _globOptions);
 			var isMatch = matcher.IsMatch(fileName);

--- a/src/EditorConfig.Tests/InMemory/InMemoryConfigTests.cs
+++ b/src/EditorConfig.Tests/InMemory/InMemoryConfigTests.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using EditorConfig.Core;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EditorConfig.Tests.InMemory
+{
+	[TestFixture]
+	public class CachingTests : EditorConfigTestBase
+	{
+		[Test]
+		public void InMemoryConfigIsUsable()
+		{
+			var configContent = @"""
+			                    root = true
+
+			                    [*]
+			                    end_of_line = lf
+			                    """;
+			var configDirectory = "C://VirtualPath/";
+			var stringReader = new StringReader(configContent);
+			var editorConfigFile = EditorConfigFile.Parse(stringReader, configDirectory);
+
+			var parser = new EditorConfigParser();
+			var config = parser.Parse("C://VirtualPath/myfile.cs", new[] { editorConfigFile });
+
+			config.EditorConfigFiles.Should().ContainSingle(f => f.IsRoot);
+		}
+	}
+}

--- a/src/EditorConfig.Tests/InMemory/InMemoryConfigTests.cs
+++ b/src/EditorConfig.Tests/InMemory/InMemoryConfigTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using EditorConfig.Core;
 using FluentAssertions;
+using Microsoft.VisualBasic;
 using NUnit.Framework;
 
 namespace EditorConfig.Tests.InMemory
@@ -30,6 +31,8 @@ namespace EditorConfig.Tests.InMemory
 		[Test]
 		public void InMemoryConfigIsUsableWithVirtualPath()
 		{
+			var virtualDirectory = Path.Combine(Directory.GetDirectoryRoot("."), "VirtualPath");
+
 			var configContent = @"""
 			                    root = true
 
@@ -37,15 +40,18 @@ namespace EditorConfig.Tests.InMemory
 			                    end_of_line = lf
 			                    """;
 			var stringReader = new StringReader(configContent);
-			var editorConfigFile = EditorConfigFile.Parse(stringReader, "C://VirtualPath");
+			var editorConfigFile = EditorConfigFile.Parse(stringReader, virtualDirectory);
 
 			var parser = new EditorConfigParser();
 
-			var config1 = parser.Parse("C://VirtualPath/myfile.cs", new[] { editorConfigFile });
+			var file = Path.Combine(virtualDirectory, "myfile.cs");
+			var config1 = parser.Parse(file, new[] { editorConfigFile });
 			config1.EditorConfigFiles.Should().ContainSingle(f => f.IsRoot);
 			config1.EndOfLine.Should().Be(EndOfLine.LF);
 
-			var config2 = parser.Parse("C://DifferentFolder/myfile.cs", new[] { editorConfigFile });
+			var directoryOutOfScope = Path.Combine(Directory.GetDirectoryRoot("."), "DifferentDirectory");
+			var fileOutOfScope = Path.Combine(directoryOutOfScope, "myfile.cs");
+			var config2 = parser.Parse(fileOutOfScope, new[] { editorConfigFile });
 			config2.EditorConfigFiles.Should().BeEmpty();
 		}
 	}

--- a/src/EditorConfig.Tests/InMemory/InMemoryConfigTests.cs
+++ b/src/EditorConfig.Tests/InMemory/InMemoryConfigTests.cs
@@ -14,17 +14,39 @@ namespace EditorConfig.Tests.InMemory
 			var configContent = @"""
 			                    root = true
 
-			                    [*]
+			                    [*.cs]
 			                    end_of_line = lf
 			                    """;
-			var configDirectory = "C://VirtualPath/";
 			var stringReader = new StringReader(configContent);
-			var editorConfigFile = EditorConfigFile.Parse(stringReader, configDirectory);
+			var editorConfigFile = EditorConfigFile.Parse(stringReader);
 
 			var parser = new EditorConfigParser();
-			var config = parser.Parse("C://VirtualPath/myfile.cs", new[] { editorConfigFile });
+			var config = parser.Parse("myfile.cs", new[] { editorConfigFile });
 
 			config.EditorConfigFiles.Should().ContainSingle(f => f.IsRoot);
+			config.EndOfLine.Should().Be(EndOfLine.LF);
+		}
+
+		[Test]
+		public void InMemoryConfigIsUsableWithVirtualPath()
+		{
+			var configContent = @"""
+			                    root = true
+
+			                    [*.cs]
+			                    end_of_line = lf
+			                    """;
+			var stringReader = new StringReader(configContent);
+			var editorConfigFile = EditorConfigFile.Parse(stringReader, "C://VirtualPath");
+
+			var parser = new EditorConfigParser();
+
+			var config1 = parser.Parse("C://VirtualPath/myfile.cs", new[] { editorConfigFile });
+			config1.EditorConfigFiles.Should().ContainSingle(f => f.IsRoot);
+			config1.EndOfLine.Should().Be(EndOfLine.LF);
+
+			var config2 = parser.Parse("C://DifferentFolder/myfile.cs", new[] { editorConfigFile });
+			config2.EditorConfigFiles.Should().BeEmpty();
 		}
 	}
 }


### PR DESCRIPTION
Hi @Mpdreamz !

I was going to use EditorConfig in Avalonia [XAML compiler](https://github.com/AvaloniaUI/Avalonia/pull/13447), and found couple of blocking problems that I think can be easily avoidable with this PR:

1. Currently EditorConfigParser forces to use editorconfig files from the file system defined in the same folder and up. It is technically a standard behavior, but MSBuild/VisualStudio can create temporal editorconfig files in an intermediate (obj) folder. Our compiler receives an array of file paths as input from the build system, and we should be able to parse them instead of iterating manually.
2. Some APIs accept EditorConfigFile as an input, but it's not possible to actually use them, since constructors were internal. This PRs adds some factory methods (two - one with a file path and the second with a TextReader parameter).
3. This library assumes that developers always have access to the file system, and we can synchronously read from it. It might not be the case in sandboxed environments. Note: it's not really the problem for Avalonia, but I can imagine editorconfig to be usable in online editors in the browser-wasm. This problem is solved by providing Parse(TextReader) overload, which can be used from the in-memory file contents.
4. EditorConfigFile instances can be reused and cached, but this problem was already solved in previous PRs in another way. So it's not really critical.
