### PR TITLE
Improve workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         git fetch --prune --unshallow --tags
         echo exit code $?
         git tag --list
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v4
       with:
           dotnet-version: |
               3.0.103

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
               6.0.302
           source-url: https://nuget.pkg.github.com/editorconfig/index.json
       env:
-          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NUGET_AUTH_TOKEN: ${{github.token}}
         
     - run: ./build.sh build -s true
       name: Build
@@ -46,14 +46,18 @@ jobs:
 
     - name: publish to github package repository
       if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
+      env:
+        GH_TOKEN: ${{ github.token }}
       shell: bash
       run:  |
-         until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true; do echo "Retrying"; sleep 1; done;
+        until dotnet nuget push 'build/output/*.nupkg' -k "$GH_TOKEN" --skip-duplicate --no-symbols true; do echo "Retrying"; sleep 1; done;
 
     - run: ./build.sh generatereleasenotes -s true
       name: Generate release notes for tag
       if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
-    - run: ./build.sh createreleaseongithub -s true --token ${{secrets.GITHUB_TOKEN}}
+      run: ./build.sh createreleaseongithub -s true --token "$GH_TOKEN"
+      env:
+        GH_TOKEN: ${{ github.token }}
       if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
       name: Create or update release for tag on github
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Always be deploying
 
 on:
   pull_request:
-    paths-ignore: 
+    paths-ignore:
       - 'README.md'
       - '.editorconfig'
   push:
@@ -10,7 +10,7 @@ on:
       - 'README.md'
       - '.editorconfig'
     branches:
-      - master 
+      - master
     tags:
       - "*.*.*"
 
@@ -34,7 +34,7 @@ jobs:
           source-url: https://nuget.pkg.github.com/editorconfig/index.json
       env:
           NUGET_AUTH_TOKEN: ${{github.token}}
-        
+
     - name: Build
       run: ./build.sh build -s true
     - name: Generate local nuget packages
@@ -60,7 +60,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: ./build.sh createreleaseongithub -s true --token "$GH_TOKEN"
-      
+
     - name: release to nuget.org
       if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,14 @@ jobs:
       env:
           NUGET_AUTH_TOKEN: ${{github.token}}
         
-    - run: ./build.sh build -s true
-      name: Build
-    - run: ./build.sh generatepackages -s true
-      name: Generate local nuget packages
-    - run: ./build.sh validatepackages -s true
-      name: "validate *.npkg files that were created"
-    - run: ./build.sh generateapichanges -s true
-      name: "Inspect public API changes"
+    - name: Build
+      run: ./build.sh build -s true
+    - name: Generate local nuget packages
+      run: ./build.sh generatepackages -s true
+    - name: "validate *.npkg files that were created"
+      run: ./build.sh validatepackages -s true
+    - name: "Inspect public API changes"
+      run: ./build.sh generateapichanges -s true
 
     - name: publish to github package repository
       if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
@@ -52,17 +52,18 @@ jobs:
       run:  |
         until dotnet nuget push 'build/output/*.nupkg' -k "$GH_TOKEN" --skip-duplicate --no-symbols true; do echo "Retrying"; sleep 1; done;
 
-    - run: ./build.sh generatereleasenotes -s true
-      name: Generate release notes for tag
+    - name: Generate release notes for tag
       if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
-      run: ./build.sh createreleaseongithub -s true --token "$GH_TOKEN"
+      run: ./build.sh generatereleasenotes -s true
+    - name: Create or update release for tag on github
+      if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
       env:
         GH_TOKEN: ${{ github.token }}
-      if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
-      name: Create or update release for tag on github
+      run: ./build.sh createreleaseongithub -s true --token "$GH_TOKEN"
       
-    - run: dotnet nuget push 'build/output/*.nupkg' -k "$NUGET_ORG_API_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true
-      name: release to nuget.org
+    - name: release to nuget.org
       if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
       env:
         NUGET_ORG_API_KEY: ${{secrets.NUGET_ORG_API_KEY}}
+      run: |
+        dotnet nuget push 'build/output/*.nupkg' -k "$NUGET_ORG_API_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,17 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       shell: bash
-      run:  |
-        until dotnet nuget push 'build/output/*.nupkg' -k "$GH_TOKEN" --skip-duplicate --no-symbols true; do echo "Retrying"; sleep 1; done;
+      run: |
+        : publish to github package repository
+        log=$(mktemp)
+        until dotnet nuget push 'build/output/*.nupkg' -k "$GH_TOKEN" --skip-duplicate --no-symbols true | tee "$log"; do
+          if grep -q '^error:.*' "$log"; then
+            perl -ne 'next unless s/^error: /::error ::/; print;' "$log"
+            exit 1
+          fi
+          echo "Retrying"
+          sleep 1
+        done
 
     - name: Generate release notes for tag
       if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
       if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
       name: Create or update release for tag on github
       
-    - run: dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.NUGET_ORG_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true
+    - run: dotnet nuget push 'build/output/*.nupkg' -k "$NUGET_ORG_API_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true
       name: release to nuget.org
       if: github.event_name == 'push' && startswith(github.ref, 'refs/tags')
+      env:
+        NUGET_ORG_API_KEY: ${{secrets.NUGET_ORG_API_KEY}}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -13,7 +13,7 @@ jobs:
         git fetch --prune --unshallow --tags
         echo exit code $?
         git tag --list
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v4
       with:
           dotnet-version: |
               3.0.103
@@ -41,7 +41,7 @@ jobs:
         git fetch --prune --unshallow --tags
         echo exit code $?
         git tag --list
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v4
       with:
           dotnet-version: |
               3.0.103

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -6,7 +6,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - run: |
@@ -34,7 +34,7 @@ jobs:
   windows:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - run: |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Core tests
       run: 'cmake . && ctest . -E "max_property_(name|value)|max_section_name_ignore" '
   windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This fixes/improves a number of items for CI:

1. Updates to current versions of actions (the old versions use obsolete versions of node and github wants to drop support for them)
2. Moves away from using `${{ ... }}` in `run:` statements (which is considered bad practice)
3. Uses `github.token` instead of `secrets.GITHUB_TOKEN` -- they reference the same thing but the former should be preferred
4. Moves `name:` field before `run:`
5. Adds permissions to jobs
6. Makes workflow stop if it can't publish
    The [existing workflow behavior for ci.yml is to run for 6 hours](https://github.com/editorconfig/editorconfig-core-net/actions/runs/14569443322) (the default github workflow time limit) which is really expensive as it blocks one of a user's 20 runner slots for 6 hours.

Note that this is only [_mostly_ tested](https://github.com/check-spelling-sandbox/editorconfig-core-net/actions). I can't get various things to pass -- some things appear to expect to run in _this_ repository, and a bunch of things require pre-existing releases and I couldn't figure out how to synthesize those either.
