### PR TITLE
Fix EditorConfigParser constructor ambiguity and inconsistency

### DIFF
--- a/src/EditorConfig.Core/EditorConfigParser.cs
+++ b/src/EditorConfig.Core/EditorConfigParser.cs
@@ -58,17 +58,26 @@ namespace EditorConfig.Core
 
 		/// <summary>
 		/// Creates an <see cref="EditorConfigParser"/> with the default filesystem and
-		/// <see cref="EditorConfigFileCache"/> enabled. This is the recommended constructor
-		/// for most use cases.
+		/// <see cref="EditorConfigFileCache"/> enabled.
 		/// </summary>
 		public EditorConfigParser() : this((IFileSystem)null) { }
+
+		/// <summary>
+		/// Creates an <see cref="EditorConfigParser"/> with a custom config file name and
+		/// optional development version. Uses the default filesystem and
+		/// <see cref="EditorConfigFileCache"/>.
+		/// </summary>
+		/// <param name="configFileName">The config file name to look for. Defaults to <c>.editorconfig</c>.</param>
+		/// <param name="developmentVersion">Only used in testing to simulate an older parser version.</param>
+		public EditorConfigParser(string configFileName, Version developmentVersion = null)
+			: this((IFileSystem)null, configFileName, developmentVersion) { }
 
 		/// <summary>
 		/// Creates an <see cref="EditorConfigParser"/> with the provided filesystem and
 		/// <see cref="EditorConfigFileCache"/> enabled.
 		/// </summary>
 		/// <param name="fileSystem">The <see cref="IFileSystem"/> to use.</param>
-		/// <param name="configFileName">The name of the editorconfig file. Defaults to <c>.editorconfig</c>.</param>
+		/// <param name="configFileName">The config file name to look for. Defaults to <c>.editorconfig</c>.</param>
 		/// <param name="developmentVersion">Only used in testing to simulate an older parser version.</param>
 		public EditorConfigParser(IFileSystem fileSystem, string configFileName = ".editorconfig", Version developmentVersion = null)
 		{
@@ -80,27 +89,12 @@ namespace EditorConfig.Core
 		}
 
 		/// <summary>
-		/// Creates an <see cref="EditorConfigParser"/> without file caching.
-		/// </summary>
-		/// <param name="configFileName">The name of the editorconfig file. Defaults to <c>.editorconfig</c>.</param>
-		/// <param name="developmentVersion">Only used in testing to simulate an older parser version.</param>
-		/// <param name="fileSystem">The <see cref="IFileSystem"/> to use. Defaults to <see cref="FileSystem"/>.</param>
-		public EditorConfigParser(string configFileName = ".editorconfig", Version developmentVersion = null, IFileSystem fileSystem = null)
-		{
-			fileSystem ??= new FileSystem();
-			Factory = path => EditorConfigFile.Parse(path, fileSystem);
-			ConfigFileName = configFileName ?? ".editorconfig";
-			ParseVersion = developmentVersion ?? Version;
-			FileSystem = fileSystem;
-		}
-
-		/// <summary>
 		/// Creates an <see cref="EditorConfigParser"/> with a custom factory.
+		/// Use this for advanced scenarios such as testing with a mock factory or
+		/// supplying pre-loaded <see cref="EditorConfigFile"/> instances.
 		/// </summary>
-		/// <param name="factory">
-		/// Function that produces an <see cref="EditorConfigFile"/> from a path.
-		/// </param>
-		/// <param name="configFileName">The name of the editorconfig file. Defaults to <c>.editorconfig</c>.</param>
+		/// <param name="factory">Function that produces an <see cref="EditorConfigFile"/> from a path.</param>
+		/// <param name="configFileName">The config file name to look for. Defaults to <c>.editorconfig</c>.</param>
 		/// <param name="developmentVersion">Only used in testing to simulate an older parser version.</param>
 		/// <param name="fileSystem">The <see cref="IFileSystem"/> to use. Defaults to <see cref="FileSystem"/>.</param>
 		public EditorConfigParser(Func<string, EditorConfigFile> factory, string configFileName = ".editorconfig", Version developmentVersion = null, IFileSystem fileSystem = null)


### PR DESCRIPTION
## Problems

Two bugs introduced in the constructor overhaul:

**1. Compile-time ambiguity** — `new EditorConfigParser(fileSystem: myFs)` matched both the `IFileSystem`-first constructor *and* the string-first constructor (which also had a `fileSystem` named parameter as its third arg), producing a compile error for any caller using the named argument form.

**2. Inconsistent caching** — `new EditorConfigParser()` used `EditorConfigFileCache` but `new EditorConfigParser(".editorconfig")` did not, despite being equivalent in intent.

## Fix

Remove `IFileSystem` from the string-first constructor (it is now covered by the `IFileSystem`-first constructor) and chain it through to the `IFileSystem` constructor so all three standard constructors use caching consistently.

The four constructors are now unambiguous by first-parameter type:

| Constructor | First param type | Caching |
|---|---|---|
| `EditorConfigParser()` | — | ✅ |
| `EditorConfigParser(string, Version?)` | `string` | ✅ |
| `EditorConfigParser(IFileSystem, string?, Version?)` | `IFileSystem` | ✅ |
| `EditorConfigParser(Func<…>, string?, Version?, IFileSystem?)` | `Func<…>` | custom |

## Verification

- Build: all 3 TFMs clean, 0 warnings
- Tests: 77/77

🤖 Generated with [Claude Code](https://claude.ai/claude-code)