### PR TITLE
Add issues: write permission to CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: aot-pack
     permissions:
-      contents: write   # create GitHub release
+      contents: write   # create GitHub release + push packages
       packages: write   # push to GitHub Packages
+      issues: write     # release-notes tool creates labels for release note categories
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The \`release-notes\` tool creates GitHub issue labels as part of generating release notes (categorising changes by \`enhancement\`, \`bug\`, \`documentation\`). This hits the \`POST /repos/{owner}/{repo}/labels\` endpoint which requires \`issues: write\`.

The \`build\` job only had \`contents: write\` and \`packages: write\`, causing a 403 on tag-push runs:

\`\`\`
{"message":"Resource not accessible by integration",
 "documentation_url":"https://docs.github.com/rest/issues/labels#create-a-label",
 "status":"403"}
\`\`\`

Adds \`issues: write\` to fix this.

Ref: https://github.com/editorconfig/editorconfig-core-net/actions/runs/26766469309/job/78894585322

🤖 Generated with [Claude Code](https://claude.ai/claude-code)