### PR TITLE
Include README.md in NuGet packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,11 +15,15 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<PackageIcon>nuget-icon.png</PackageIcon>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<None Include="../../README.md" Pack="true" PackagePath="README.md">
+			<Link>README.md</Link>
+		</None>
 		<Content Include="../../nuget-icon.png" CopyToOutputDirectory="PreserveNewest">
 			<Link>nuget-icon.png</Link>
 			<Pack>True</Pack>


### PR DESCRIPTION
Adds `PackageReadmeFile` and a `README.md` `None` item to `src/Directory.Build.props` so the README is included in all packable projects (`editorconfig` library, `editorconfig-tool`). NuGet.org will display it on the package page.

The icon (`nuget-icon.png`) was already packaged via the same props file — this adds the missing README alongside it.

Verified by inspecting the produced `.nupkg`:
\`\`\`
README.md       5126 bytes
nuget-icon.png  1965 bytes
\`\`\`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)